### PR TITLE
Option to immediately acquire lock if same owner

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -32,6 +32,7 @@ type acquireLockOptions struct {
 	additionalTimeToWaitForLock time.Duration
 	additionalAttributes        map[string]*dynamodb.AttributeValue
 	sessionMonitor              *sessionMonitor
+	noWaitOnSameOwner           bool
 }
 
 type getLockOptions struct {
@@ -47,6 +48,7 @@ type getLockOptions struct {
 	data                              []byte
 	additionalAttributes              map[string]*dynamodb.AttributeValue
 	failIfLocked                      bool
+	noWaitOnSameOwner                 bool
 }
 
 type releaseLockOptions struct {


### PR DESCRIPTION
This PR adds a `AcquireLockOption` called `WithNoWaitOnSameOwner`. By using it in the Aquire lock the library will check if the existing lock has the same owner than the one used by the client in order to automatically expired the old lock. 

This way can be used to give distinctive owners to the look and allow the same owner to recover a stalled lock without waiting for lease expiration.

In my use case, I use I give clients the hostname as the owner so I can be sure jus one host is executing the locked task but the host that executed it is able to recover a stalled lock without waiting.