### PR TITLE
Add options to acquire lock on local clock expire

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -33,6 +33,7 @@ type acquireLockOptions struct {
 	additionalAttributes        map[string]*dynamodb.AttributeValue
 	sessionMonitor              *sessionMonitor
 	noWaitOnSameOwner           bool
+	unsafeClockExpire           bool
 }
 
 type getLockOptions struct {
@@ -49,6 +50,7 @@ type getLockOptions struct {
 	additionalAttributes              map[string]*dynamodb.AttributeValue
 	failIfLocked                      bool
 	noWaitOnSameOwner                 bool
+	unsafeClockExpire                 bool
 }
 
 type releaseLockOptions struct {


### PR DESCRIPTION
This PR adds two options One for the client and another for the acquire lock

Client option `WithUtcCreationDate()` adds the UTC creation date to the locks. This option in the client is required to use it in combination with unsafe expires.

Acquire lock option `WithUnsafeLocalClockExpire` will consider the lock expired if the UTC creation date and the duration exceeds the current UTC date. This method is unsafe as it relies on the local clock is in sync with the clock that created the lock